### PR TITLE
Add options for visibility of group and adding ldap description. Fix …

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ How to configure config.json
     "private_token": "xxxxxxxxxxxxxxxxxxxx",          // Token generated in GitLab for an user with admin access
     "oauth_token": "",
     "ldap_provider":"",                               // Name of your LDAP provider in gitlab.yml
-    "create_user": true                               // Should the script create the user in GitLab
+    "create_user": true,                              // Should the script create the user in GitLab
+    "group_visibility": "private",                    // Set visibility level of new group (private, internal, public)
+    "add_description": true                           // Add description from your LDAP as group description
   },
   "ldap": {
     "url": "ldaps://ldap.loc",                        // URL to your ldap / active directory

--- a/config.json
+++ b/config.json
@@ -6,7 +6,9 @@
     "private_token": "",
     "oauth_token": "",
     "ldap_provider":"",
-    "create_user": true
+    "create_user": true,
+    "group_visibility": "private",
+    "add_description": true
   },
   "ldap": {
     "url": "",


### PR DESCRIPTION
Hello MrBE4R,

this commit add 2 options:
* visibility of newly created groups
* use LDAP description as group description

The commit also fixes the problem that newly created gitlab groups are not recognized as they are not known as already existing groups. 