### PR TITLE
Add option to configure ssl_verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ How to configure config.json
   "log_level": "INFO",                                // The log level
   "gitlab": {
     "api": "https://gitlab.example.com",              // Url of your GitLab 
+    "ssl_verify": true,                               // Verify SSL certificate when using HTTPs (true, false, path to own CA bundle)
     "private_token": "xxxxxxxxxxxxxxxxxxxx",          // Token generated in GitLab for an user with admin access
     "oauth_token": "",
     "ldap_provider":"",                               // Name of your LDAP provider in gitlab.yml

--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
   "log_level": "INFO",
   "gitlab": {
     "api": "",
+    "ssl_verify": true,
     "private_token": "",
     "oauth_token": "",
     "ldap_provider":"",

--- a/gitlab-ldap-sync.py
+++ b/gitlab-ldap-sync.py
@@ -34,9 +34,9 @@ if __name__ == "__main__":
                 logging.error('You should set at most one auth information in config.json, aborting.')
             else:
                 if config['gitlab']['private_token']:
-                    gl = gitlab.Gitlab(url=config['gitlab']['api'], private_token=config['gitlab']['private_token'])
+                    gl = gitlab.Gitlab(url=config['gitlab']['api'], private_token=config['gitlab']['private_token'], ssl_verify=config['gitlab']['ssl_verify'])
                 elif config['gitlab']['oauth_token']:
-                    gl = gitlab.Gitlab(url=config['gitlab']['api'], oauth_token=config['gitlab']['oauth_token'])
+                    gl = gitlab.Gitlab(url=config['gitlab']['api'], oauth_token=config['gitlab']['oauth_token'], ssl_verify=config['gitlab']['ssl_verify'])
                 else:
                     gl = None
                 if gl is None:


### PR DESCRIPTION
Hallo MrBE4R,

this commit add an option to configure ssl_verify. Disabling or using an own ca bundle is required if gitlab api is only available via https secured by a company internal CA.

For more information see:
https://github.com/python-gitlab/python-gitlab/commit/4c3aa23775f509aa1c69732ea0a66262f1f5269e